### PR TITLE
Add autosave/autoload feature

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,8 @@
 	branch = miniui-miyoomini
 [submodule "third-party/picoarch"]
 	path = third-party/picoarch
-	url = https://github.com/shauninman/picoarch.git
-	branch = miniui-miyoomini
+	url = https://github.com/goweiwen/picoarch.git
+	branch = autosave
 [submodule "third-party/vvvvvv"]
 	path = third-party/vvvvvv
 	url = https://github.com/shauninman/VVVVVV.git

--- a/commits.txt
+++ b/commits.txt
@@ -1,6 +1,6 @@
 5e600602  DinguxCommander
 608ebfc1  SDL-1.2
-ab7f0294  picoarch
+e838dd9e  picoarch
 76e45c34  libpicofe
 88252880  libretro-common
 15e0485e  vvvvvv

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -12,7 +12,7 @@
 #define MAX_BRIGHTNESS 10
 
 #define HINT_SLEEP "POWER"
-#define HINT_RESUME "X"
+#define HINT_RESET "X"
 
 #define SDLK_UNDEFINED -1
 
@@ -71,7 +71,6 @@ typedef enum ButtonIndex {
 // TODO: considering moving resume to START on all platforms?
 // but then we need to extend the can_start and can_select behavior too...
 #define kButtonSleep kButtonPower
-#define kButtonResume kButtonX
 #define kButtonAltEmu kButtonY
 
 typedef struct UnionPaths {

--- a/src/libmmenu/mmenu.c
+++ b/src/libmmenu/mmenu.c
@@ -47,7 +47,7 @@ __attribute__((constructor)) static void init(void) {
 	items[kItemSave] 		= "Save";
 	items[kItemLoad] 		= "Load";
 	items[kItemAdvanced] 	= is_simple ? "Reset" : "Advanced";
-	items[kItemExitGame] 	= "Quit";
+	items[kItemExitGame] 	= "Save & Quit";
 	
 	GFX_init();
 	
@@ -587,6 +587,11 @@ MenuReturnStatus ShowMenu(char* rom_path, char* save_path_template, SDL_Surface*
 				break;
 				case kItemExitGame:
 					status = kStatusExitGame;
+					if (total_discs) {
+						char* disc_path = disc_paths[disc];
+						putFile(txt_path, disc_path + strlen(base_path));
+					}
+					putInt(slot_path, 9);
 					quit = 1;
 				break;
 			}

--- a/src/miniui/main.c
+++ b/src/miniui/main.c
@@ -1514,26 +1514,25 @@ int main (int argc, char *argv[]) {
 			}
 
 			GFX_blitRule(screen, Screen.main.rule.bottom_y);
-			GFX_blitPill(screen, HINT_SLEEP, "SLEEP", Screen.buttons.left, Screen.buttons.top);
 
 			if (show_version) {
-				GFX_blitButton(screen, "B", "BACK", -Screen.buttons.right, Screen.buttons.top, Screen.button.text.ox_B);
+				GFX_blitButton(screen, "B", "BACK", Screen.buttons.left, Screen.buttons.top, Screen.button.text.ox_B);
 			}
 			else if (total==0) {
 				if (stack->count>1) {
-					GFX_blitButton(screen, "B", "BACK", -Screen.buttons.right, Screen.buttons.top, Screen.button.text.ox_B);
+					GFX_blitButton(screen, "B", "BACK", Screen.buttons.left, Screen.buttons.top, Screen.button.text.ox_B);
 				}
 			}
 			else {
 				int button_width;
 				if (can_resume) {
-					button_width = GFX_blitButton(screen, "A", "RESUME", -Screen.buttons.right, Screen.buttons.top, Screen.button.text.ox_A);
+					button_width = GFX_blitButton(screen, "A", "CONTINUE", -Screen.buttons.right, Screen.buttons.top, Screen.button.text.ox_A);
 				}
 				else {
 					button_width = GFX_blitButton(screen, "A", "START", -Screen.buttons.right, Screen.buttons.top, Screen.button.text.ox_A);
 				}
 				if (stack->count>1) {
-					GFX_blitButton(screen, "B", "BACK", -(Screen.buttons.right+button_width+Screen.buttons.gutter),Screen.buttons.top, Screen.button.text.ox_B);
+					GFX_blitButton(screen, "B", "BACK", Screen.buttons.left, Screen.buttons.top, Screen.button.text.ox_B);
 				}
 			}
 		}


### PR DESCRIPTION
# Introduction
This PR adds an autosave/autoload feature and makes it the default behaviour:
- When quitting a game, automatically saves a state to slot 9.
- When loading a rom, automatically loads from slot 9 if state exists.

Some changes are required to the `picoarch` submodule. If you plan to merge this, I suggest forking `picoarch` and merging those changes as well.

# Details
### Main Menu
- "A" key prompt will now show either "Continue" or "Start" depending on whether an autosave is present.
- Remove "POWER: Sleep" prompt, moved "B: Back" to the left.
- Remove "X: Resume" button as it's no longer needed.

### `mmenu`
- When selecting "Quit", you can now press "X" to restart the game. This is necessary since it is no longer possible to cold boot without going into the advanced menu.
- In mmenu, "Quit" is renamed to "Save & Quit" when save states are allowed.
- Remove "POWER: Sleep" prompt, moved "B: Back" to the left.

### `picoarch`
- FAKE-08 save states are disabled. They don't work and break the autoload feature.
- When quitting, autosaves to slot 9.